### PR TITLE
Link fixing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 
 A module for [bitcore][bitcore] that implements [Payment Channels][channel]. Payment channels (sometimes referred as micropayment channels) are a type of smart contracts that allow rapidly adjusting bitcoin transactions. This can be used to do trustless simultaneous payments with a service provider without the need of an intermediary, and some other applications.
 
-See [the main bitcore repo][bitcore] or the [bitcore guide on Payment Channels](http://bitcore.io/guide/channel.html) for more information.
+See [the main bitcore repo][bitcore] or the [bitcore guide on Payment Channels](http://bitcore.io/guide/module/channel/index.html) for more information.
 
 ## Contributing
 
-See [CONTRIBUTING.md](https://github.com/bitpay/bitcore) on the main bitcore repo for information about how to contribute.
+See [CONTRIBUTING.md](https://github.com/bitpay/bitcore/blob/master/CONTRIBUTING.md) on the main bitcore repo for information about how to contribute.
 
 ## License
 
@@ -19,5 +19,5 @@ Code released under [the MIT license](https://github.com/bitpay/bitcore/blob/mas
 
 Copyright 2013-2015 BitPay, Inc. Bitcore is a trademark maintained by BitPay, Inc.
 
-[bitcore]: http://github.com/bitpay/bitcore
+[bitcore]: https://github.com/bitpay/bitcore
 [channel]: https://bitcoin.org/en/developer-guide#micropayment-channel


### PR DESCRIPTION
The link to the bitcore guide was broken. I also updated the
CONTRIBUTING link to point directly to the document rather than the
repository home. And http->https.