### PR TITLE
Fix for setupRefund bug (Issue #19)

### DIFF
--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -119,6 +119,10 @@ function Consumer(opts) {
 Consumer.prototype.processFunding = function(utxo) {
   $.checkArgument(_.isObject(utxo), 'Can only process an array of objects or an object');
   this.commitmentTx.from(utxo);
+  var size = this.commitmentTx._estimateSize();
+  var fee  = this.commitmentTx._estimateFee(size, 0);
+  this.commitmentTx.to(this.commitmentTx.address, this.commitmentTx.amount - fee);
+
 };
 
 /**
@@ -127,6 +131,7 @@ Consumer.prototype.processFunding = function(utxo) {
  * @return {bitcore.Transaction}
  */
 Consumer.prototype.setupRefund = function() {
+//  this.commitmentTx.to(refundAddress, this.commitmentTx._getInputAmount() - )
   this.commitmentTx.sign(this.fundingKey);
   $.checkState(this.commitmentTx.isFullySigned());
   var amount = this.commitmentTx.amount;
@@ -136,11 +141,15 @@ Consumer.prototype.setupRefund = function() {
     satoshis: amount,
     script: this.commitmentTx.outputs[0].script
   };
+
   this.refundTx = new Refund()
-    .from(multisigOut, this.commitmentTx.publicKeys, 2)
-    .change(this.refundAddress);
+    .from(multisigOut, this.commitmentTx.publicKeys, 2);
+    //.change(this.refundAddress);
+  var size = this.refundTx._estimateSize();
+  var fee  = this.refundTx._estimateFee(size, 0);
+  this.refundTx.to(this.refundAddress, amount - fee);
   this.refundTx.inputs[0].sequenceNumber = 0;
-  this.refundTx._updateChangeOutput();
+//  this.refundTx._updateChangeOutput();
   this.refundTx.nLockTime = this.expires;
   return this.refundTx;
 };

--- a/lib/consumer.js
+++ b/lib/consumer.js
@@ -131,7 +131,6 @@ Consumer.prototype.processFunding = function(utxo) {
  * @return {bitcore.Transaction}
  */
 Consumer.prototype.setupRefund = function() {
-//  this.commitmentTx.to(refundAddress, this.commitmentTx._getInputAmount() - )
   this.commitmentTx.sign(this.fundingKey);
   $.checkState(this.commitmentTx.isFullySigned());
   var amount = this.commitmentTx.amount;
@@ -144,12 +143,10 @@ Consumer.prototype.setupRefund = function() {
 
   this.refundTx = new Refund()
     .from(multisigOut, this.commitmentTx.publicKeys, 2);
-    //.change(this.refundAddress);
   var size = this.refundTx._estimateSize();
   var fee  = this.refundTx._estimateFee(size, 0);
   this.refundTx.to(this.refundAddress, amount - fee);
   this.refundTx.inputs[0].sequenceNumber = 0;
-//  this.refundTx._updateChangeOutput();
   this.refundTx.nLockTime = this.expires;
   return this.refundTx;
 };

--- a/lib/transactions/commitment.js
+++ b/lib/transactions/commitment.js
@@ -27,7 +27,7 @@ function Commitment(opts) {
   this.publicKeys = opts.publicKeys;
   this.outscript = Script.buildMultisigOut(this.publicKeys, 2);
   this.address = this.outscript.toScriptHashOut().toAddress();
-  this.change(this.address);
+  //this.change(this.address);
 
   Object.defineProperty(this, 'amount', {
     configurable: false,

--- a/lib/transactions/commitment.js
+++ b/lib/transactions/commitment.js
@@ -27,7 +27,6 @@ function Commitment(opts) {
   this.publicKeys = opts.publicKeys;
   this.outscript = Script.buildMultisigOut(this.publicKeys, 2);
   this.address = this.outscript.toScriptHashOut().toAddress();
-  //this.change(this.address);
 
   Object.defineProperty(this, 'amount', {
     configurable: false,


### PR DESCRIPTION
Hey I fixed the bug was preventing the refund exchange from getting thru, cuz we're using bitcore and need payment channel code to work. 

It seems to be something to do with how Transaction.change was being used, so I used Transaction.to in place of it, calculating the fees manually. 

I tested it on code communicating with BitcoinJ and it successfully did the refund exchange. 

Wasn't able to figure out how to do gulp lint etc. on it, as there was no lint target in the gulp file, but I don't understand gulp very well. If anybody wants to help me out with that, I'll run the unit tests and stuff.